### PR TITLE
Travis CI Testing: Clang & GCC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # Compiled help files
 *.chm
+
+# Compiled executables
+*.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,38 @@
 language: cpp
+sudo: false
+
 compiler:
   - clang
-script: cd projects/gcc/Test; make
+  - gcc
+
+cache:
+  apt: true
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-precise-3.5
+    packages:
+      - g++-4.9
+      - clang-3.5
+
+before_install:
+  - if [ "$CXX" == "g++" ]; then
+        export CXX=g++-4.9;
+        export CC=gcc-4.9;
+    elif [ "$CXX" == "clang++" ]; then
+        export CXX=clang++-3.5;
+        export CC=clang-3.5;
+    fi
+  - echo "$CXX $CC"
+
+script:
+  #############################################################################
+  - cd projects/gcc/Test
+  - make CC=$CXX
+  - cd -
+  #############################################################################
+  - cd projects/gcc/Time
+  - make CC=$CXX
+  - cd -

--- a/projects/gcc/Time/Makefile
+++ b/projects/gcc/Time/Makefile
@@ -29,10 +29,10 @@ CXXFLAGS = -Wall -Wextra -Weffc++ -std=c++11 -I$(INCDIR)
 all: time_performance_opt.exe time_performance_nonopt.exe run_tests
 
 time_performance_opt.exe: time_performance.cpp $(HEADERS)
-	$(CC) $(CXXFLAGS) -O2 -o time_performance_opt.exe $^
+	$(CC) $(CXXFLAGS) -O2 $< -o $@
 
 time_performance_nonopt.exe: time_performance.cpp $(HEADERS)
-	$(CC) $(CXXFLAGS) -o time_performance_nonopt.exe $^
+	$(CC) $(CXXFLAGS) $< -o $@
 
 run_tests:
 	./time_performance_opt.exe


### PR DESCRIPTION
Updates travis CI testing for the tests in "projects/".

- also test gcc 4.9
- also test timing tool (so it does not get outdated)